### PR TITLE
Add guidance in README & issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/cms.md
+++ b/.github/ISSUE_TEMPLATE/cms.md
@@ -1,0 +1,23 @@
+---
+name: CMS
+about: Submit an issue about the W3C Craft CMS
+title: ''
+labels: craft-cms
+assignees: ''
+
+---
+
+**Describe the issue**
+A clear and concise description of what the issue is.
+
+**To reproduce**
+Steps to reproduce the behavior, including URLs.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/content.md
+++ b/.github/ISSUE_TEMPLATE/content.md
@@ -1,0 +1,20 @@
+---
+name: Content
+about: Submit an issue about W3C website content
+title: ''
+labels: content
+assignees: ''
+
+---
+
+**Describe the issue**
+A clear and concise description of what the problem is.
+
+**URL**
+The URL where this problem occurs.
+
+**Recommended solution**
+A clear description of how you think the content should be updated.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/design_system.md
+++ b/.github/ISSUE_TEMPLATE/design_system.md
@@ -1,0 +1,20 @@
+---
+name: Design System
+about: Submit an issue about the W3C Design System
+title: ''
+labels: design-system
+assignees: ''
+
+---
+
+**Describe the issue**
+A clear and concise description of what the problem is.
+
+**URL**
+The URL where this problem occurs.
+
+**Recommended solution**
+A clear description of how you think the design system should be updated.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/website.md
+++ b/.github/ISSUE_TEMPLATE/website.md
@@ -1,0 +1,24 @@
+---
+name: Website
+about: Submit an issue about the W3C website
+title: ''
+labels: website
+assignees: ''
+
+---
+
+**Describe the issue**
+A clear and concise description of what the issue is.
+
+**To reproduce**
+Steps to reproduce the behavior, including URLs. It's useful to include your web browser and version number to help 
+review any potential browser issues.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
 # W3C Website feedback and bug reports
-W3C Website feedback and bug reports
+
+This repo is used to manage feedback and bug reports for the W3C website redesign project. 
+
+This includes the following projects:
+
+* [Design System](https://github.com/w3c/w3c-website-templates-bundle/) - https://design-system.w3.org/
+* [W3C website](https://github.com/w3c/w3c-website-frontend)
+* [Craft CMS](https://github.com/w3c/w3c-website-craft)
+
+Submitted issues are triaged by W3C and then actioned by the team. 
 
 If you are unable to use GitHub, or do not wish your feedback to be public, please write us an [email](mailto:team-website-redesign@w3.org) instead.


### PR DESCRIPTION
Add guidance on how to use this repo & which projects/websites it is for to the README.

Add issue templates to help auto-tag incoming issues.